### PR TITLE
Escape ampersand in cinderblock.xml

### DIFF
--- a/cinderblock.xml
+++ b/cinderblock.xml
@@ -3,7 +3,7 @@
         name="CinderVR"
         id="io.stainless.cinderVR"
         git="https://github.com/RussTheAerialist/CinderVR.git"
-        author="RussTheAerialist & Joxn"
+        author="RussTheAerialist &amp; Joxn"
         version="0.1"
         url="https://github.com/RussTheAerialist/CinderVR"
         library="https://developer.oculus.com/download"


### PR DESCRIPTION
It appears as though TinderBox doesn't have this issue, but other tools will die during parse when an unescaped ampersand is encountered.